### PR TITLE
[FEAT/#4] Tab 컴포넌트 완성

### DIFF
--- a/components/Tab/index.tsx
+++ b/components/Tab/index.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRef, useEffect, useState } from "react";
+import { TabProps } from "@/types/tab";
+import styles from "./tab.module.css";
+
+export default function Tab({ tabs, focusedTab, onTabClick }: TabProps) {
+  const tabRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [underlineStyle, setUnderlineStyle] = useState({});
+
+  useEffect(() => {
+    const focusedIndex = tabs.findIndex((tab) => tab === focusedTab);
+    const focusedTabRef = tabRefs.current[focusedIndex];
+
+    if (focusedTabRef) {
+      setUnderlineStyle({
+        left: focusedTabRef.offsetLeft,
+        width: focusedTabRef.offsetWidth,
+      });
+    }
+  }, [focusedTab, tabs]);
+
+  return (
+    <div className={styles.tab}>
+      {tabs.map((tab, index) => (
+        <div
+          key={tab}
+          ref={(el) => {
+            tabRefs.current[index] = el;
+          }}
+          className={`${styles.item} ${
+            focusedTab === tab ? styles.focused : ""
+          }`}
+          onClick={() => onTabClick(tab)}
+        >
+          {tab}
+        </div>
+      ))}
+      <div className={styles.underline} style={underlineStyle} />
+    </div>
+  );
+}

--- a/components/Tab/tab.module.css
+++ b/components/Tab/tab.module.css
@@ -1,0 +1,32 @@
+.tab {
+  position: relative;
+  padding: 0 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--theme-border-default);
+}
+
+.item {
+  padding: 10px 18px;
+  cursor: pointer;
+  color: var(--theme-text-secondary);
+  font-size: var(--text-body-2-size);
+  font-weight: var(--text-body-2-weight);
+  line-height: var(--text-body-2-line-height);
+  position: relative;
+  transition: color 0.3s ease;
+  z-index: 1;
+}
+
+.item.focused {
+  color: var(--theme-text-primary);
+}
+
+.underline {
+  position: absolute;
+  bottom: -1px;
+  height: 2px;
+  background-color: var(--theme-text-primary);
+  transition: left 0.3s ease-in-out, width 0.3s ease-in-out;
+}

--- a/types/tab.ts
+++ b/types/tab.ts
@@ -1,0 +1,5 @@
+export interface TabProps {
+  tabs: string[];
+  focusedTab: string;
+  onTabClick: (tab: string) => void;
+}


### PR DESCRIPTION
close #4;

## 주요 변경사항
 - Tab 컴포넌트 완성
 - prop으로 tab 목록 전달하여 동적 렌더링
 - 자연스러운 transition 효과 포함